### PR TITLE
Bump fabric api version to support 1.21

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,4 @@ maven_group=cookiesmod
 archives_base_name=cookies-mod
 
 # Dependencies
-fabric_version=0.99.4+1.21
+fabric_version=0.100.0+1.21


### PR DESCRIPTION
Changes the fabric api version from `0.99.4+1.21` to `0.100.0+1.21`.