### PR TITLE
fix: hotm utils only calculate next 9

### DIFF
--- a/src/main/java/dev/morazzer/cookies/mod/features/mining/utils/HotmUtils.java
+++ b/src/main/java/dev/morazzer/cookies/mod/features/mining/utils/HotmUtils.java
@@ -163,7 +163,7 @@ public class HotmUtils {
 				if (perk == null) {
 					return;
 				}
-				int amount = perk.calculateNextN(9, perkLevel);
+				int amount = perk.calculateNextN(10, perkLevel);
 				lines.add(index++,
 						Text.literal("%s ".formatted(numberFormat.format(amount)))
 								.append(perk.powderTypes().getName())


### PR DESCRIPTION
Hotm utils used to only calculate the cost for the next 9 perks instead of the advertised 10