### PR TITLE
Fix IndexOutOfBoundsException caused by writing "$" in the item search

### DIFF
--- a/src/main/java/codes/cookies/mod/services/item/search/SearchQueryMatcher.java
+++ b/src/main/java/codes/cookies/mod/services/item/search/SearchQueryMatcher.java
@@ -57,7 +57,7 @@ public class SearchQueryMatcher implements ItemSearchFilter {
 				builder.negate();
 			}
 
-			if (stringBuffer.peek() == '$' && stringBuffer.peek(1) == ':') {
+			if (stringBuffer.canRead(2) && stringBuffer.peek() == '$' && stringBuffer.peek(1) == ':') {
 				stringBuffer.skip();
 				stringBuffer.skip();
 				builder.regex();


### PR DESCRIPTION
Problem:
Crash if you write $ in the itemSearchField

Caused by:
If the StringBuffer only contains one character we can't peek at the "offset 1" character to see if it's a `:`

Fix:
Check if we have enough characters to peek at before peeking